### PR TITLE
Use distinct component name for operator2

### DIFF
--- a/pkg/cmd/operator2/cmd.go
+++ b/pkg/cmd/operator2/cmd.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	componentName      = "cluster-osin-operator"
+	componentName      = "cluster-osin-operator2"
 	componentNamespace = "openshift-core-operators"
 )
 


### PR DESCRIPTION
This prevents leader election conflicts between the two operators.

Signed-off-by: Monis Khan <mkhan@redhat.com>