### PR TITLE
feat(operator2/auth): create default Authentication instance

### DIFF
--- a/manifests/0000_09_cluster-osin-operator_08_authentication_cr.yaml
+++ b/manifests/0000_09_cluster-osin-operator_08_authentication_cr.yaml
@@ -1,4 +1,0 @@
-apiVersion: config.openshift.io/v1
-kind: Authentication
-metadata:
-  name: cluster

--- a/manifests/0000_09_cluster-osin-operator_09_oauth_cr.yaml
+++ b/manifests/0000_09_cluster-osin-operator_09_oauth_cr.yaml
@@ -1,8 +1,0 @@
-apiVersion: config.openshift.io/v1
-kind: OAuth
-metadata:
-  name: cluster
-spec:
-  tokenConfig:
-    accessTokenMaxAgeSeconds: 86400
-    authorizeTokenMaxAgeSeconds: 300

--- a/pkg/operator2/auth.go
+++ b/pkg/operator2/auth.go
@@ -1,25 +1,82 @@
 package operator2
 
 import (
+	"fmt"
+	"github.com/golang/glog"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
 )
 
-func (c *authOperator) handleAuthConfig() (*configv1.Authentication, error) {
-	auth, err := c.authentication.Get(configName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
+func defaultAuthentication(name, metadataConfigMapName string) *configv1.Authentication {
+	return &configv1.Authentication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: defaultLabels(),
+			Annotations: map[string]string{
+				// TODO - better annotations & messaging to user about defaulting behavior
+				"message": "Default Authentication created by cluster-authentication-operator",
+			},
+		},
+		Spec: configv1.AuthenticationSpec{
+			Type: configv1.AuthenticationTypeIntegratedOAuth,
+		},
+		Status: configv1.AuthenticationStatus{
+			IntegratedOAuthMetadata: configv1.ConfigMapNameReference{
+				Name: metadataConfigMapName,
+			},
+		},
 	}
 
-	expectedReference := configv1.ConfigMapNameReference{
-		Name: targetName,
+}
+func (c *authOperator) fetchAuthConfig() (*configv1.Authentication, error) {
+	// Fetch any existing Authentication instance
+	glog.V(5).Infof("fetching authentication resource '%s'", c.configName)
+	existing, err := c.authentication.Get(c.configName, metav1.GetOptions{})
+	if err == nil || !apierrors.IsNotFound(err) {
+		// Existing instance found, or unknown error
+		return existing, err
 	}
 
-	if auth.Status.IntegratedOAuthMetadata == expectedReference {
-		return auth, nil
+	// No existing instance found; attempt to create default
+	glog.V(5).Infof("creating default authentication resource '%s': metadataConfigMap '%s'", c.configName, c.targetName)
+	created, err := c.authentication.Create(defaultAuthentication(c.configName, c.targetName))
+	if err == nil || !apierrors.IsAlreadyExists(err) {
+		// Default successfully created, or unknown error
+		return created, err
 	}
 
-	auth.Status.IntegratedOAuthMetadata = expectedReference
-	return c.authentication.UpdateStatus(auth)
+	// An Authentication instance must have been created between when we
+	// first checked and when we attempted to create the default.
+	// Find the existing instance, returning any errors trying to fetch it
+	glog.V(5).Infof("re-fetching authentication resource '%s'", c.configName)
+	return c.authentication.Get(c.configName, metav1.GetOptions{})
+}
+
+func (c *authOperator) updateAuthStatus(auth *configv1.Authentication) (*configv1.Authentication, error) {
+	if auth == nil {
+		glog.V(5).Info("no authentication resource to update status for")
+		return nil, nil
+	}
+	var expectedRef configv1.ConfigMapNameReference
+	switch auth.Spec.Type {
+	case configv1.AuthenticationTypeNone:
+		expectedRef = auth.Spec.OAuthMetadata
+	case configv1.AuthenticationTypeIntegratedOAuth:
+		expectedRef = configv1.ConfigMapNameReference{
+			Name: c.targetName,
+		}
+	default:
+		return nil, fmt.Errorf("unknown AuthenticationType '%s'", auth.Spec.Type)
+	}
+
+	if auth.Status.IntegratedOAuthMetadata != expectedRef {
+		auth.Status.IntegratedOAuthMetadata = expectedRef
+		glog.V(4).Infof("updating status for authentication resource '%s' to %#v", auth.GetName(), auth.Status)
+		return c.authentication.UpdateStatus(auth)
+	}
+	glog.V(5).Infof("authentication resource '%s' status already up to date", auth.GetName())
+	return auth, nil
 }

--- a/pkg/operator2/auth_test.go
+++ b/pkg/operator2/auth_test.go
@@ -1,0 +1,9 @@
+package operator2
+
+import (
+	"testing"
+)
+
+func TestEnsureAuthentication(t *testing.T) {
+	// TODO
+}

--- a/pkg/operator2/configmap.go
+++ b/pkg/operator2/configmap.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	routev1 "github.com/openshift/api/route/v1"
 )
@@ -41,11 +42,13 @@ func getMetadata(route *routev1.Route) string {
 	return strings.TrimSpace(fmt.Sprintf(stubMetadata, host, host, host))
 }
 
-func getMetadataConfigMap(route *routev1.Route) *corev1.ConfigMap {
-	meta := defaultMeta()
-	meta.Namespace = configNamespace
+func getMetadataConfigMap(name string, namespace string, route *routev1.Route) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
-		ObjectMeta: meta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    defaultLabels(),
+		},
 		Data: map[string]string{
 			metadataKey: getMetadata(route),
 		},

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -24,20 +25,20 @@ import (
 )
 
 const (
-	targetName = "openshift-osin"
-
 	metadataKey = "metadata"
 	configKey   = "config.yaml"
 	sessionKey  = "session"
 	sessionPath = "/var/session"
-
-	configName      = "cluster"
-	configNamespace = "openshift-managed-config"
-
-	authOperatorConfigResourceName = "cluster"
 )
 
 type authOperator struct {
+	targetName             string
+	targetNamespace        string
+	configName             string
+	configNamespace        string
+	managedConfigNamespace string
+	authOperatorConfigName string
+
 	authOperatorConfig authopclient.AuthenticationOperatorConfigInterface
 
 	recorder events.Recorder
@@ -54,6 +55,13 @@ type authOperator struct {
 }
 
 func NewAuthenticationOperator(
+	targetName string,
+	targetNamespace string,
+	configName string,
+	configNamespace string,
+	managedConfigNamespace string,
+	authOpConfigResourceName string,
+
 	authOpConfigInformer authopinformer.AuthenticationOperatorConfigInformer,
 	authOpConfigClient authopclient.AuthenticationOperatorConfigsGetter,
 	kubeInformersNamespaced informers.SharedInformerFactory,
@@ -65,11 +73,18 @@ func NewAuthenticationOperator(
 	recorder events.Recorder,
 ) operator.Runner {
 	c := &authOperator{
+		targetName:             targetName,
+		targetNamespace:        targetNamespace,
+		configName:             configName,
+		configNamespace:        configNamespace,
+		managedConfigNamespace: managedConfigNamespace,
+		authOperatorConfigName: authOpConfigResourceName,
+
 		authOperatorConfig: authOpConfigClient.AuthenticationOperatorConfigs(),
 
 		recorder: recorder,
 
-		route: routeClient.Routes(targetName),
+		route: routeClient.Routes(targetNamespace),
 
 		services:    kubeClient.CoreV1(),
 		secrets:     kubeClient.CoreV1(),
@@ -83,9 +98,9 @@ func NewAuthenticationOperator(
 	coreInformers := kubeInformersNamespaced.Core().V1()
 	configV1Informers := configInformers.Config().V1()
 
-	authOpConfigNameFilter := operator.FilterByNames(authOperatorConfigResourceName)
-	osinNameFilter := operator.FilterByNames(targetName)
-	configNameFilter := operator.FilterByNames(configName)
+	authOpConfigNameFilter := operator.FilterByNames(c.authOperatorConfigName)
+	osinNameFilter := operator.FilterByNames(c.targetName)
+	configNameFilter := operator.FilterByNames(c.configName)
 
 	return operator.New("AuthenticationOperator2", c,
 		operator.WithInformer(authOpConfigInformer, authOpConfigNameFilter),
@@ -103,7 +118,7 @@ func NewAuthenticationOperator(
 }
 
 func (c *authOperator) Key() (metav1.Object, error) {
-	return c.authOperatorConfig.Get(authOperatorConfigResourceName, metav1.GetOptions{})
+	return c.authOperatorConfig.Get(c.authOperatorConfigName, metav1.GetOptions{})
 }
 
 func (c *authOperator) Sync(obj metav1.Object) error {
@@ -123,76 +138,83 @@ func (c *authOperator) Sync(obj metav1.Object) error {
 }
 
 func (c *authOperator) handleSync(configOverrides []byte) error {
-	route, err := c.handleRoute()
-	if err != nil {
-		return err
-	}
+	glog.V(3).Infof("begin sync")
 
-	metadataConfigMap, _, err := resourceapply.ApplyConfigMap(c.configMaps, c.recorder, getMetadataConfigMap(route))
-	if err != nil {
-		return err
-	}
+	glog.V(4).Infof("using config overrides  %q", configOverrides)
 
-	auth, err := c.handleAuthConfig()
+	auth, err := c.fetchAuthConfig()
 	if err != nil {
+		glog.V(1).Infof("falure fetching Authentication resource: %v", err)
 		return err
 	}
+	if auth.Spec.Type == configv1.AuthenticationTypeIntegratedOAuth {
+		oauth, err := c.fetchOAuthConfig()
+		if err != nil || oauth == nil {
+			return err
+		}
 
-	service, _, err := resourceapply.ApplyService(c.services, c.recorder, defaultService())
-	if err != nil {
-		return err
-	}
+		route, err := c.handleRoute()
+		glog.V(5).Infof("handled route: err=%v route=%#v", err, route)
+		if err != nil {
+			return err
+		}
 
-	sessionSecret, err := c.expectedSessionSecret()
-	if err != nil {
-		return err
-	}
-	secret, _, err := resourceapply.ApplySecret(c.secrets, c.recorder, sessionSecret)
-	if err != nil {
-		return err
-	}
+		expectedOAuthConfigMap, err := c.configMapForOAuth(oauth, route, configOverrides)
+		glog.V(5).Infof("got configmap for oauth: err=%v  cm=%#v", err, expectedOAuthConfigMap)
+		if err != nil {
+			return err
+		}
+		metadataConfigMap := getMetadataConfigMap(c.targetName, c.managedConfigNamespace, route)
+		_, _, err = resourceapply.ApplyConfigMap(c.configMaps, c.recorder, metadataConfigMap)
+		glog.V(5).Infof("applied metadata configmap: err=%v  cm=%#v", err, metadataConfigMap)
+		if err != nil {
+			return err
+		}
+		srv := defaultService(c.targetName, c.targetNamespace)
+		_, _, err = resourceapply.ApplyService(c.services, c.recorder, srv)
+		glog.V(5).Infof("applied service: err=%v srv=%#v", err, srv)
+		if err != nil {
+			return err
+		}
 
-	expectedOAuthConfigMap, err := c.handleOAuthConfig(configOverrides)
-	if err != nil {
-		return err
-	}
-	configMap, _, err := resourceapply.ApplyConfigMap(c.configMaps, c.recorder, expectedOAuthConfigMap)
-	if err != nil {
-		return err
-	}
+		sessionSecret, err := c.expectedSessionSecret()
+		glog.V(5).Infof("got expected session secret: err=%v name=%s namespace=%s", err, sessionSecret.GetName(), sessionSecret.GetNamespace())
+		if err != nil {
+			return err
+		}
+		secret, _, err := resourceapply.ApplySecret(c.secrets, c.recorder, sessionSecret)
+		glog.V(5).Infof("applied session secret: err=%v name=%s namespace=%s", err, secret.GetName(), secret.GetNamespace())
+		if err != nil {
+			return err
+		}
+		configMap, _, err := resourceapply.ApplyConfigMap(c.configMaps, c.recorder, expectedOAuthConfigMap)
+		glog.V(5).Infof("applied oauth configmap: err=%v name=%s namespace=%s", err, expectedOAuthConfigMap.GetName(), expectedOAuthConfigMap.GetNamespace())
+		if err != nil {
+			return err
+		}
 
-	// deployment, have RV of all resources
-	// TODO use ExpectedDeploymentGeneration func
-	// TODO probably do not need every RV
-	expectedDeployment := defaultDeployment(
-		route.ResourceVersion,
-		metadataConfigMap.ResourceVersion,
-		auth.ResourceVersion,
-		service.ResourceVersion,
-		secret.ResourceVersion,
-		configMap.ResourceVersion,
-	)
-	deployment, _, err := resourceapply.ApplyDeployment(c.deployments, c.recorder, expectedDeployment, c.getGeneration(), false)
-	if err != nil {
-		return err
+		// deployment, have RV of all resources
+		// TODO use ExpectedDeploymentGeneration func
+		// TODO probably do not need every RV
+		expectedDeployment := defaultDeployment(
+			c.targetName,
+			c.targetNamespace,
+			secret.ResourceVersion,
+			configMap.ResourceVersion,
+		)
+		_, _, err = resourceapply.ApplyDeployment(c.deployments, c.recorder, expectedDeployment, c.getGeneration(), false)
+		glog.V(5).Infof("applied deployment: err=%v name=%s namespace=%s", err, expectedDeployment.GetName(), expectedDeployment.GetNamespace())
+		if err != nil {
+			return err
+		}
 	}
-
-	glog.V(4).Infof("current deployment: %#v", deployment)
-
-	return nil
+	_, err = c.updateAuthStatus(auth)
+	glog.V(5).Infof("updated auth status: err=%v", err)
+	return err
 }
 
 func defaultLabels() map[string]string {
 	return map[string]string{
-		"app": "origin-cluster-osin-operator2",
-	}
-}
-
-func defaultMeta() metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Name:            targetName,
-		Namespace:       targetName,
-		Labels:          defaultLabels(),
-		OwnerReferences: nil, // TODO
+		"app": "cluster-authentication-operator",
 	}
 }

--- a/pkg/operator2/route.go
+++ b/pkg/operator2/route.go
@@ -11,9 +11,9 @@ import (
 )
 
 func (c *authOperator) handleRoute() (*routev1.Route, error) {
-	route, err := c.route.Get(targetName, metav1.GetOptions{})
+	route, err := c.route.Get(c.targetName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		return c.route.Create(defaultRoute())
+		return c.route.Create(defaultRoute(c.targetName, c.targetNamespace))
 	}
 	if err != nil {
 		return nil, err
@@ -25,9 +25,13 @@ func (c *authOperator) handleRoute() (*routev1.Route, error) {
 	return route, nil
 }
 
-func defaultRoute() *routev1.Route {
+func defaultRoute(targetName, namespace string) *routev1.Route {
 	return &routev1.Route{
-		ObjectMeta: defaultMeta(),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      targetName,
+			Namespace: namespace,
+			Labels:    defaultLabels(),
+		},
 		Spec: routev1.RouteSpec{
 			To: routev1.RouteTargetReference{
 				Kind: "Service",

--- a/pkg/operator2/secret_test.go
+++ b/pkg/operator2/secret_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestRandomString(t *testing.T) {
@@ -40,7 +41,10 @@ func TestIsValidSessionSecret(t *testing.T) {
 
 func secret(sessionSecret []byte) *v1.Secret {
 	return &v1.Secret{
-		ObjectMeta: defaultMeta(),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "session-secret-test",
+			Namespace: "auth-operator-test",
+		},
 		Data: map[string][]byte{
 			sessionKey: sessionSecret,
 		},

--- a/pkg/operator2/service.go
+++ b/pkg/operator2/service.go
@@ -2,12 +2,17 @@ package operator2
 
 import (
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func defaultService() *v1.Service {
+func defaultService(targetName, targetNamespace string) *v1.Service {
 	return &v1.Service{
-		ObjectMeta: defaultMeta(),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      targetName,
+			Namespace: targetNamespace,
+			Labels:    defaultLabels(),
+		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
 				{

--- a/pkg/operator2/starter.go
+++ b/pkg/operator2/starter.go
@@ -24,6 +24,13 @@ import (
 const (
 	resync = 20 * time.Minute
 
+	targetName                     = "integrated-oauthserver"
+	targetNamespace                = "openshift-authentication"
+	configName                     = "cluster"
+	configNamespace                = "openshift-config"
+	managedConfigNamespace         = "openshift-config-managed"
+	authOperatorConfigResourceName = "cluster"
+
 	authConfigResource = `
 apiVersion: authentication.operator.openshift.io/v1alpha1
 kind: AuthenticationOperatorConfig
@@ -85,6 +92,12 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	)
 
 	operator := NewAuthenticationOperator(
+		targetName,
+		targetNamespace,
+		configName,
+		configNamespace,
+		managedConfigNamespace,
+		authOperatorConfigResourceName,
 		authOperatorConfigInformers.Authentication().V1alpha1().AuthenticationOperatorConfigs(),
 		authConfigClient.AuthenticationV1alpha1(),
 		kubeInformersNamespaced,


### PR DESCRIPTION
Ensure the cluster has a `Authentication` config by creating a default `Authentication` resource when one does not otherwise exist.