### PR TITLE
Honor route name assigned to our service in our config

### DIFF
--- a/pkg/operator2/configmap.go
+++ b/pkg/operator2/configmap.go
@@ -12,8 +12,8 @@ import (
 const stubMetadata = `
 {
   "issuer": "%s",
-  "authorization_endpoint": "%s/oauth/authorize",
-  "token_endpoint": "%s/oauth/token",
+  "authorization_endpoint": "https://%s/oauth/authorize",
+  "token_endpoint": "https://%s/oauth/token",
   "scopes_supported": [
     "user:check-access",
     "user:full",

--- a/pkg/operator2/oauth.go
+++ b/pkg/operator2/oauth.go
@@ -13,11 +13,12 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 )
 
-func (c *authOperator) handleOAuthConfig(configOverrides []byte) (*corev1.ConfigMap, error) {
+func (c *authOperator) handleOAuthConfig(route *routev1.Route, configOverrides []byte) (*corev1.ConfigMap, error) {
 	oauthConfig, err := c.oauth.Get(configName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -108,8 +109,8 @@ func (c *authOperator) handleOAuthConfig(configOverrides []byte) (*corev1.Config
 			// which needs to direct the user to the real public URL (MasterPublicURL)
 			// that means we still need to get that value from the installer's config
 			// TODO ask installer team to make it easier to get that URL
-			MasterURL:                   "https://127.0.0.1:443",
-			MasterPublicURL:             "https://127.0.0.1:443",
+			MasterURL:                   fmt.Sprintf("https://%s", route.Spec.Host),
+			MasterPublicURL:             fmt.Sprintf("https://%s", route.Spec.Host),
 			AssetPublicURL:              "", // TODO do we need this?
 			AlwaysShowProviderSelection: false,
 			IdentityProviders:           identityProviders,

--- a/pkg/operator2/operator.go
+++ b/pkg/operator2/operator.go
@@ -152,7 +152,7 @@ func (c *authOperator) handleSync(configOverrides []byte) error {
 		return err
 	}
 
-	expectedOAuthConfigMap, err := c.handleOAuthConfig(configOverrides)
+	expectedOAuthConfigMap, err := c.handleOAuthConfig(route, configOverrides)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator2/route.go
+++ b/pkg/operator2/route.go
@@ -18,11 +18,51 @@ func (c *authOperator) handleRoute() (*routev1.Route, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if len(route.Spec.Host) == 0 {
 		return nil, fmt.Errorf("route has no host: %#v", route)
 	}
-	// TODO make sure route is correct
+
+	if err := isValidRoute(route); err != nil {
+		// delete the route so that it is replaced with the proper one in next reconcile loop
+		c.route.Delete(route.Name, &metav1.DeleteOptions{})
+		return nil, err
+	}
+
 	return route, nil
+}
+
+func isValidRoute(route *routev1.Route) error {
+	// TODO: return all errors at once
+
+	// get the expected settings from the default route
+	expectedRoute := defaultRoute()
+	expName := expectedRoute.Spec.To.Name
+	expPort := expectedRoute.Spec.Port.TargetPort.IntValue()
+	expTLSTermination := expectedRoute.Spec.TLS.Termination
+	expInsecureEdgeTerminationPolicy := expectedRoute.Spec.TLS.InsecureEdgeTerminationPolicy
+
+	if route.Spec.To.Name != expName {
+		return fmt.Errorf("route targets a wrong service - needs %s: %#v", expName, route)
+	}
+
+	if route.Spec.Port.TargetPort.IntValue() != expPort {
+		return fmt.Errorf("expected port '%d' for route: %#v", expPort, route)
+	}
+
+	if route.Spec.TLS == nil {
+		return fmt.Errorf("TLS needs to be configured for route: %#v", route)
+	}
+
+	if route.Spec.TLS.Termination != expTLSTermination {
+		return fmt.Errorf("route contains wrong TLS termination - '%s' is required: %#v", expTLSTermination, route)
+	}
+
+	if route.Spec.TLS.InsecureEdgeTerminationPolicy != routev1.InsecureEdgeTerminationPolicyRedirect {
+		return fmt.Errorf("route contains wrong insecure termination policy - '%s' is required: %#v", expInsecureEdgeTerminationPolicy, route)
+	}
+
+	return nil
 }
 
 func defaultRoute() *routev1.Route {


### PR DESCRIPTION
This PR makes the route that we create be honored in our OAuth configuration in order for OSIN to be reachable.

I also did a check of the Route object we create according to https://docs.okd.io/latest/architecture/networking/routes.html. The behavior of the Route is described in the commit message of the second commit.