### PR TITLE
Fix informers to correctly watch secrets and configmaps

### DIFF
--- a/pkg/operator2/helpers.go
+++ b/pkg/operator2/helpers.go
@@ -12,10 +12,10 @@ func moveSecretFromRefToFileStringSource(syncData []idpSyncData, i int, name con
 
 func getFilenameFromConfigMapNameRef(syncData []idpSyncData, i int, name configv1.ConfigMapNameReference, key string) string {
 	// TODO make sure this makes sense (some things are optional)
-	return syncData[i].configMaps[getName(i, name.Name, key)].path
+	return syncData[i].configMaps[getIDPName(i, name.Name, key)].path
 }
 
 func getFilenameFromSecretNameRef(syncData []idpSyncData, i int, name configv1.SecretNameReference, key string) string {
 	// TODO make sure this makes sense (some things are optional)
-	return syncData[i].secrets[getName(i, name.Name, key)].path
+	return syncData[i].secrets[getIDPName(i, name.Name, key)].path
 }


### PR DESCRIPTION
We still need to add code to handle the syncData redeployment case.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 